### PR TITLE
Adding MultiTheme class.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,20 +21,11 @@ jobs:
           - os: ubuntu-latest
             python: "3.9"
             sphinx: "3.5.4"
-          - os: ubuntu-latest
-            python: "3.9"
-            sphinx: "2.4.5"
-          - os: ubuntu-latest
-            python: "3.9"
-            sphinx: "1.8.6"
-          - os: ubuntu-latest
-            python: "3.9"
-            sphinx: "1.7.9"
     runs-on: "${{matrix.os}}"
     steps:
       - {name: Check out repository code, uses: actions/checkout@v2}
       - {name: Initialize dependencies, id: init, uses: Robpol86/actions-init-deps-py@v3,
-         with: {python-version: "${{matrix.python}}", postargs: " -E docs"}}
+         with: {python-version: "${{matrix.python}}", postargs: " -E docs", cache-buster: "${{matrix.sphinx}}"}}
       - {name: Remove OpenGraph, run: "poetry remove sphinxext-opengraph; poetry remove -D $_", if: "startsWith(matrix.sphinx, '1.')"}
       - {name: Downgrade Sphinx, run: "poetry add --dev sphinx=${{matrix.sphinx}}", if: "${{matrix.sphinx}}"}
       - {name: Run lints, run: make lint}

--- a/sphinx_multi_theme/multi_theme.py
+++ b/sphinx_multi_theme/multi_theme.py
@@ -13,6 +13,16 @@ Example output file structure:
     docs/_build/html/theme_classic/index.html
 """
 from dataclasses import dataclass, field
+from typing import Dict, Iterator, List, Tuple, Union
+
+from sphinx.application import Sphinx
+from sphinx.config import Config
+from sphinx.errors import SphinxError
+from sphinx.util import logging
+
+from sphinx_multi_theme import __version__
+
+CONFIG_NAME_INTERNAL_THEMES = "multi_theme__INTERNAL__themes"
 
 
 @dataclass
@@ -27,3 +37,115 @@ class Theme:
     def is_primary(self) -> bool:
         """Theme is considered the primary theme if it has no subdir specified."""
         return not self.subdir
+
+
+class MultiTheme:
+    """Builds copies documentation using multiple themes.
+
+    The first theme is considered the primary theme whilst remaining themes are considered secondary and will be built into
+    subdirectories.
+    """
+
+    DIRECTORY_PREFIX = "theme_"
+
+    def __init__(self, themes: List[Union[str, Theme]]):
+        """Constructor.
+
+        :param themes: List of theme names as strings (e.g. ["classic"] or list of Theme instances (e.g. [Theme("classic")]).
+        """
+        themes_ = []
+        for theme in themes:
+            themes_.append(theme if hasattr(theme, "subdir") else Theme(theme))
+        self.themes = themes_
+        self.set_active(0)
+        self.set_subdir_attrs()
+
+    def __len__(self) -> int:
+        """Return length of self.themes."""
+        return len(self.themes)
+
+    def __getitem__(self, item) -> Theme:
+        """Allows class to act as a dict or a list."""
+        try:
+            return self.themes[item]
+        except TypeError:
+            return {t.name: t for t in self.themes}[item]
+
+    def __iter__(self) -> Iterator[Theme]:
+        """Yield themes."""
+        yield from self.themes
+
+    def items(self) -> Iterator[Tuple[str, Theme]]:
+        """Yield name and theme pairs."""
+        for theme in self.themes:
+            yield theme.name, theme
+
+    def set_active(self, idx: int) -> Theme:
+        """Set theme at specific index as active and set all other themes as inactive.
+
+        :return: The active theme.
+        """
+        active_theme = self.themes[idx]
+        active_theme.is_active = True
+        for idx2, theme in enumerate(self.themes):
+            if idx == idx2:
+                continue
+            theme.is_active = False
+        return active_theme
+
+    @property
+    def active(self) -> Theme:
+        """Return the active theme."""
+        themes = [t for t in self.themes if t.is_active]
+        return themes[0]
+
+    def set_subdir_attrs(self):
+        """Set subdir attribute for every theme except the first one."""
+        primary_theme = self.themes[0]
+        if primary_theme.subdir:
+            raise SphinxError("Primary theme cannot have a subdir")
+
+        secondary_themes = self.themes[1:]
+        visited: Dict[str, Theme] = {}
+        for theme in secondary_themes:
+            if theme.subdir:
+                # User specified custom subdir.
+                if theme.subdir in visited:
+                    raise SphinxError(f"Subdir collision: {visited[theme.subdir]} and {theme}")
+            else:
+                subdir = f"{self.DIRECTORY_PREFIX}{theme.name}"
+                if subdir in visited:
+                    i = 2
+                    while f"{subdir}{i}" in visited:
+                        i += 1
+                    subdir = f"{subdir}{i}"
+                theme.subdir = subdir
+            visited[theme.subdir] = theme
+
+
+def flatten_html_theme(_: Sphinx, config: Config):
+    """Replace MultiTheme instance with a string (the active theme's name).
+
+    :param _: Sphinx application.
+    :param config: Sphinx configuration.
+    """
+    multi_themes: Union[str, MultiTheme] = config["html_theme"]
+    try:
+        config["html_theme"] = multi_themes.active.name
+    except AttributeError:
+        log = logging.getLogger(__name__)
+        log.warning("Sphinx config value for `html_theme` not a %s instance", MultiTheme.__name__)
+    else:
+        config[CONFIG_NAME_INTERNAL_THEMES][:] = multi_themes
+
+
+def setup(app: Sphinx) -> Dict[str, str]:
+    """Called by Sphinx during phase 0 (initialization).
+
+    :param app: Sphinx application.
+
+    :returns: Extension version.
+    """
+    app.add_config_value(CONFIG_NAME_INTERNAL_THEMES, [], "html")
+    app.connect("config-inited", flatten_html_theme)
+    return dict(version=__version__)

--- a/tests/unit_tests/test_docs/__init__.py
+++ b/tests/unit_tests/test_docs/__init__.py
@@ -1,0 +1,1 @@
+"""End to end unit tests with sphinx.testing."""

--- a/tests/unit_tests/test_docs/conftest.py
+++ b/tests/unit_tests/test_docs/conftest.py
@@ -1,0 +1,27 @@
+"""pytest fixtures."""
+from pathlib import Path
+
+import pytest
+from sphinx.testing.path import path
+from sphinx.testing.util import SphinxTestApp
+
+pytest_plugins = "sphinx.testing.fixtures"  # pylint: disable=invalid-name
+
+
+@pytest.fixture(scope="session")
+def rootdir() -> path:
+    """Used by sphinx.testing, return the directory containing all test docs."""
+    return path(__file__).parent.abspath()
+
+
+@pytest.fixture(name="sphinx_app")
+def _sphinx_app(app: SphinxTestApp) -> SphinxTestApp:
+    """Instantiate a new Sphinx app per test function."""
+    app.build()
+    yield app
+
+
+@pytest.fixture(name="outdir")
+def _outdir(sphinx_app: SphinxTestApp) -> Path:
+    """Return the Sphinx output directory with HTML files."""
+    return Path(sphinx_app.outdir)

--- a/tests/unit_tests/test_docs/test-single-theme/incomplete/conf.py
+++ b/tests/unit_tests/test_docs/test-single-theme/incomplete/conf.py
@@ -1,0 +1,6 @@
+"""Sphinx test configuration."""
+exclude_patterns = ["_build"]
+extensions = ["sphinx_multi_theme.multi_theme"]
+master_doc = "index"
+nitpicky = True
+html_theme = "classic"

--- a/tests/unit_tests/test_docs/test-single-theme/incomplete/index.rst
+++ b/tests/unit_tests/test_docs/test-single-theme/incomplete/index.rst
@@ -1,0 +1,10 @@
+====
+Test
+====
+
+Sample documentation.
+
+.. toctree::
+    :caption: Main
+
+    other

--- a/tests/unit_tests/test_docs/test-single-theme/incomplete/other.rst
+++ b/tests/unit_tests/test_docs/test-single-theme/incomplete/other.rst
@@ -1,0 +1,5 @@
+=====
+Other
+=====
+
+Another page.

--- a/tests/unit_tests/test_docs/test-single-theme/off/conf.py
+++ b/tests/unit_tests/test_docs/test-single-theme/off/conf.py
@@ -1,0 +1,5 @@
+"""Sphinx test configuration."""
+exclude_patterns = ["_build"]
+master_doc = "index"
+nitpicky = True
+html_theme = "classic"

--- a/tests/unit_tests/test_docs/test-single-theme/off/index.rst
+++ b/tests/unit_tests/test_docs/test-single-theme/off/index.rst
@@ -1,0 +1,10 @@
+====
+Test
+====
+
+Sample documentation.
+
+.. toctree::
+    :caption: Main
+
+    other

--- a/tests/unit_tests/test_docs/test-single-theme/off/other.rst
+++ b/tests/unit_tests/test_docs/test-single-theme/off/other.rst
@@ -1,0 +1,5 @@
+=====
+Other
+=====
+
+Another page.

--- a/tests/unit_tests/test_docs/test-single-theme/on/conf.py
+++ b/tests/unit_tests/test_docs/test-single-theme/on/conf.py
@@ -1,0 +1,9 @@
+"""Sphinx test configuration."""
+from sphinx_multi_theme.multi_theme import MultiTheme
+
+
+exclude_patterns = ["_build"]
+extensions = ["sphinx_multi_theme.multi_theme"]
+master_doc = "index"
+nitpicky = True
+html_theme = MultiTheme(["classic"])

--- a/tests/unit_tests/test_docs/test-single-theme/on/index.rst
+++ b/tests/unit_tests/test_docs/test-single-theme/on/index.rst
@@ -1,0 +1,10 @@
+====
+Test
+====
+
+Sample documentation.
+
+.. toctree::
+    :caption: Main
+
+    other

--- a/tests/unit_tests/test_docs/test-single-theme/on/other.rst
+++ b/tests/unit_tests/test_docs/test-single-theme/on/other.rst
@@ -1,0 +1,5 @@
+=====
+Other
+=====
+
+Another page.

--- a/tests/unit_tests/test_docs/test_single_theme.py
+++ b/tests/unit_tests/test_docs/test_single_theme.py
@@ -1,0 +1,132 @@
+"""Tests."""
+import re
+from filecmp import clear_cache, DEFAULT_IGNORES, dircmp
+from io import StringIO
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+EXPECTED_NUM_FILES = 23
+IGNORE = DEFAULT_IGNORES + [".buildinfo"]
+ROOTS = ("single-theme/off", "single-theme/on", "single-theme/incomplete")
+
+
+def directory_compare(left: Optional[Path] = None, right: Optional[Path] = None, compare: Optional[dircmp] = None) -> int:
+    """Recursively compare two directories and their file contents.
+
+    :return: Number of common files found recursively.
+    """
+    clear_cache()
+    if not compare:
+        compare = dircmp(left, right, ignore=IGNORE)
+
+    # Verify no errors found by dircmp.
+    assert not compare.funny_files
+    assert not compare.common_funny
+
+    # Verify all non-recursive files/directories in both directories are the same.
+    assert not compare.left_only
+    assert not compare.right_only
+    assert not compare.diff_files
+
+    # Verify file contents.
+    file_count = 0
+    for name in compare.same_files:
+        left_file = Path(compare.left) / name
+        right_file = Path(compare.right) / name
+        assert left_file.read_bytes() == right_file.read_bytes()
+        file_count += 1
+
+    # Recurse.
+    for common_sub_dir in compare.subdirs.values():
+        file_count += directory_compare(compare=common_sub_dir)
+
+    return file_count
+
+
+@pytest.mark.parametrize("testroot", [pytest.param(r, marks=pytest.mark.sphinx("html", testroot=r)) for r in ROOTS])
+def test(outdir: Path, warning: StringIO, testroot: str):
+    """Verify single-theme is the same as not using this feature."""
+    assert (outdir / "index.html").is_file()
+
+    # Diff all files.
+    parts = outdir.parts
+    if testroot.endswith("on"):
+        idx = parts.index("on")
+    elif testroot.endswith("incomplete"):
+        idx = parts.index("incomplete")
+    else:
+        idx = None
+    if idx is not None:
+        outdir_off = Path(*(parts[:idx] + ("off",) + parts[idx + 1 :]))  # noqa
+        assert directory_compare(outdir, outdir_off) == EXPECTED_NUM_FILES
+
+    # Check warnings.
+    warnings = warning.getvalue().strip()
+    if testroot.endswith("incomplete"):
+        warnings_sans_colors = re.sub(r"\x1b\[[0-9;]+m", "", warnings)
+        assert warnings_sans_colors == "WARNING: Sphinx config value for `html_theme` not a MultiTheme instance"
+    else:
+        assert not warnings
+
+
+def test_directory_compare(tmp_path: Path):
+    """Sanity checks to verify function works as expected."""
+    left = tmp_path / "left"
+    right = tmp_path / "right"
+
+    def run():
+        return directory_compare(left, right)
+
+    # Setup both directories identically.
+    for path in (left, right):
+        path.mkdir()
+        path.joinpath("one.txt").write_text("One", encoding="utf8")
+        path.joinpath("two.txt").write_text("Two", encoding="utf8")
+        path.joinpath("three.txt").write_text("Three", encoding="utf8")
+        sub_path = path / "sub"
+        sub_path.mkdir()
+        sub_path.joinpath("four.txt").write_text("Four", encoding="utf8")
+    assert run() == 4
+
+    # Extra file.
+    for path in (left, right):
+        path.joinpath("shoe.txt").write_text("Shoe", encoding="utf8")
+        with pytest.raises(AssertionError):
+            run()
+        path.joinpath("shoe.txt").unlink()
+        run()
+
+    # Extra file in subdir.
+    for path in (left, right):
+        sub_path = path / "new"
+        sub_path.mkdir()
+        sub_path.joinpath("buckle.txt").write_text("Buckle", encoding="utf8")
+        with pytest.raises(AssertionError):
+            run()
+        sub_path.joinpath("buckle.txt").unlink()
+        with pytest.raises(AssertionError):
+            run()  # Empty left over directory.
+        sub_path.rmdir()
+        run()
+
+    # Different size file.
+    for path in (left, right):
+        file_ = path.joinpath("one.txt")
+        file_.write_text("Cowabunga", encoding="utf8")
+        with pytest.raises(AssertionError):
+            run()
+        file_.write_text("One", encoding="utf8")
+        run()
+
+    # Same size different contents in a file.
+    for path in (left, right):
+        file_ = path.joinpath("one.txt")
+        old_size = file_.stat().st_size
+        file_.write_text("ONE", encoding="utf8")
+        assert file_.stat().st_size == old_size
+        with pytest.raises(AssertionError):
+            run()
+        file_.write_text("One", encoding="utf8")
+        run()

--- a/tests/unit_tests/test_multi_theme.py
+++ b/tests/unit_tests/test_multi_theme.py
@@ -1,0 +1,109 @@
+"""Tests."""
+import pytest
+from sphinx.errors import SphinxError
+
+from sphinx_multi_theme.multi_theme import MultiTheme, Theme
+
+
+def test():
+    """Test."""
+    with pytest.raises(IndexError):
+        MultiTheme([])
+
+    themes = MultiTheme(["a", "b", "c"])
+    assert len(themes) == 3
+
+
+def test_as_list_and_dict():
+    """Test."""
+    themes = MultiTheme(["a", "b", "c"])
+
+    # Act as a list.
+    assert themes[0].name == "a"
+    assert themes[1].name == "b"
+    assert themes[2].name == "c"
+    results = []
+    for theme in themes:
+        results.append(theme.name)
+    assert results == ["a", "b", "c"]
+
+    # Act as a dict.
+    assert themes["a"].name == "a"
+    assert themes["b"].name == "b"
+    assert themes["c"].name == "c"
+    results = []
+    for key, theme in themes.items():
+        results.append((key, theme.name))
+    assert results == [("a", "a"), ("b", "b"), ("c", "c")]
+
+
+def test_active():
+    """Test."""
+    themes = MultiTheme(["a", "b", "c"])
+
+    assert themes[0].is_active is True
+    assert themes[1].is_active is False
+    assert themes[2].is_active is False
+    assert themes.active.name == "a"
+
+    themes.set_active(0)
+    assert themes[0].is_active is True
+    assert themes[1].is_active is False
+    assert themes[2].is_active is False
+    assert themes.active.name == "a"
+
+    themes.set_active(1)
+    assert themes[0].is_active is False
+    assert themes[1].is_active is True
+    assert themes[2].is_active is False
+    assert themes.active.name == "b"
+
+    themes.set_active(2)
+    assert themes[0].is_active is False
+    assert themes[1].is_active is False
+    assert themes[2].is_active is True
+    assert themes.active.name == "c"
+
+    with pytest.raises(IndexError):
+        themes.set_active(3)
+
+
+def test_subdir_attrs():
+    """Test."""
+    themes = MultiTheme(["a", "b", "c"])
+    assert themes[0].subdir == ""
+    assert themes[1].subdir == "theme_b"
+    assert themes[2].subdir == "theme_c"
+
+    themes = MultiTheme(["a", "b", "b"])
+    assert themes[0].subdir == ""
+    assert themes[1].subdir == "theme_b"
+    assert themes[2].subdir == "theme_b2"
+
+    themes = MultiTheme(["a", "a", "a", "a"])
+    assert themes[0].subdir == ""
+    assert themes[1].subdir == "theme_a"
+    assert themes[2].subdir == "theme_a2"
+    assert themes[3].subdir == "theme_a3"
+
+    themes = MultiTheme(["a"])
+    assert themes[0].subdir == ""
+
+    themes = MultiTheme([Theme("a"), Theme("b", "my_subdir")])
+    assert themes[0].subdir == ""
+    assert themes[1].subdir == "my_subdir"
+
+    themes = MultiTheme(["a", Theme("b", "theme_c"), "c"])
+    assert themes[0].subdir == ""
+    assert themes[1].subdir == "theme_c"
+    assert themes[2].subdir == "theme_c2"
+
+    with pytest.raises(SphinxError) as exc:
+        MultiTheme([Theme("a", "my_subdir")])
+    assert exc.value.args[0] == "Primary theme cannot have a subdir"
+
+    with pytest.raises(SphinxError) as exc:
+        MultiTheme(["a", Theme("b", "my_subdir"), Theme("c", "my_subdir")])
+    first = "Theme(name='b', subdir='my_subdir', is_active=False)"
+    second = "Theme(name='c', subdir='my_subdir', is_active=False)"
+    assert exc.value.args[0] == f"Subdir collision: {first} and {second}"


### PR DESCRIPTION
Adding MultiTheme class, the entrypoint of the extension.

Using config-inited Sphinx API event to update Sphinx config and turn
`html_theme` back into a string. This API requires dropping support for
Sphinx 2.4 and below.

Separate GitHub Actions cache key via cache-buster when downgrading
version of Sphinx.