### PR TITLE
Implementing `primary` property.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ build:
 	poetry build -n -vvv
 
 docs/_build/html/index.html::
-	poetry run sphinx-build -n -W docs $(@D)
+	poetry run sphinx-build -T -n -W docs $(@D)
 	@echo Documentation available here: $@
 
 .PHONY: docs

--- a/sphinx_multi_theme/multi_theme.py
+++ b/sphinx_multi_theme/multi_theme.py
@@ -32,12 +32,12 @@ def flatten_html_theme(_: Sphinx, config: Config):
     """
     multi_theme_instance: Union[str, MultiTheme] = config["html_theme"]
     try:
-        active_theme_name = multi_theme_instance.active.name
+        primary_theme_name = multi_theme_instance.primary.name
     except AttributeError:
         log = logging.getLogger(__name__)
         log.warning("Sphinx config value for `html_theme` not a %s instance", MultiTheme.__name__)
     else:
-        config["html_theme"] = active_theme_name
+        config["html_theme"] = primary_theme_name
         config[CONFIG_NAME_INTERNAL_THEMES] = multi_theme_instance
 
 

--- a/sphinx_multi_theme/theme.py
+++ b/sphinx_multi_theme/theme.py
@@ -79,6 +79,12 @@ class MultiTheme:
         themes = [t for t in self.themes if t.is_active]
         return themes[0]
 
+    @property
+    def primary(self) -> Theme:
+        """Return the primary theme."""
+        themes = [t for t in self.themes if t.is_primary]
+        return themes[0]
+
     def set_subdir_attrs(self):
         """Set subdir attribute for every theme except the first one."""
         primary_theme = self.themes[0]

--- a/tests/unit_tests/test_multi_theme.py
+++ b/tests/unit_tests/test_multi_theme.py
@@ -68,6 +68,16 @@ def test_active():
         themes.set_active(3)
 
 
+def test_primary():
+    """Test."""
+    themes = MultiTheme(["a", "b", "c"])
+
+    assert themes[0].is_primary is True
+    assert themes[1].is_primary is False
+    assert themes[2].is_primary is False
+    assert themes.primary.name == "a"
+
+
 def test_subdir_attrs():
     """Test."""
     themes = MultiTheme(["a", "b", "c"])


### PR DESCRIPTION
Switching `flatten_html_theme()` to use primary instead of active
property. Active will be used in forked processes in the near future.

`make docs` will now print traceback on exception via `-T` option.