### PR TITLE
Adding multi_theme_print_files Sphinx option.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,10 @@ html_copy_source = False
 html_theme = MultiTheme(["sphinx_rtd_theme"])
 
 
+# Options for sphinx-multi-theme.
+multi_theme_print_files = True
+
+
 # https://sphinxext-opengraph.readthedocs.io/en/latest/#options
 ogp_site_name = project
 ogp_type = "website"

--- a/poetry.lock
+++ b/poetry.lock
@@ -184,6 +184,17 @@ python-versions = ">=3.5"
 docutils = ">=0.14"
 
 [[package]]
+name = "emoji"
+version = "1.7.0"
+description = "Emoji for Python"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+dev = ["pytest", "coverage", "coveralls"]
+
+[[package]]
 name = "flake8"
 version = "4.0.1"
 description = "the modular source code checker: pep8 pyflakes and co"
@@ -434,6 +445,18 @@ rtd = ["ipython", "sphinx-book-theme (>=0.1.0,<0.2.0)", "sphinx-panels (>=0.5.2,
 testing = ["beautifulsoup4", "coverage", "docutils (>=0.17.0,<0.18.0)", "pytest (>=3.6,<4)", "pytest-cov", "pytest-regressions"]
 
 [[package]]
+name = "natsort"
+version = "8.1.0"
+description = "Simple yet flexible natural sorting in Python."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+fast = ["fastnumbers (>=2.0.0)"]
+icu = ["PyICU (>=1.0.0)"]
+
+[[package]]
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
@@ -674,6 +697,18 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
+name = "seedir"
+version = "0.3.0"
+description = "Package for creating, editing, and reading folder tree diagrams."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+emoji = "*"
+natsort = "*"
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -691,7 +726,7 @@ python-versions = "*"
 
 [[package]]
 name = "soupsieve"
-version = "2.3.1"
+version = "2.3.2"
 description = "A modern CSS selector implementation for Beautiful Soup."
 category = "dev"
 optional = false
@@ -954,7 +989,7 @@ docs = ["sphinx-autobuild", "sphinx-copybutton", "sphinx-notfound-page", "sphinx
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "611a629dac37ff5033b0770c6a0b487fa469fcffeafcbaa08705cee2b989fc0b"
+content-hash = "cc7359595a957541fdb88270fd09aa7c75b7aa19d2df60ce9dd672dcb2de5742"
 
 [metadata.files]
 alabaster = [
@@ -1086,6 +1121,9 @@ docutils = [
 docutils-stubs = [
     {file = "docutils-stubs-0.0.22.tar.gz", hash = "sha256:1736d9650cfc20cff8c72582806c33a5c642694e2df9e430717e7da7e73efbdf"},
     {file = "docutils_stubs-0.0.22-py3-none-any.whl", hash = "sha256:157807309de24e8c96af9a13afe207410f1fc6e5aab5d974fd6b9191f04de327"},
+]
+emoji = [
+    {file = "emoji-1.7.0.tar.gz", hash = "sha256:65c54533ea3c78f30d0729288998715f418d7467de89ec258a31c0ce8660a1d1"},
 ]
 flake8 = [
     {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
@@ -1271,6 +1309,10 @@ myst-parser = [
     {file = "myst-parser-0.16.1.tar.gz", hash = "sha256:a6473b9735c8c74959b49b36550725464f4aecc4481340c9a5f9153829191f83"},
     {file = "myst_parser-0.16.1-py3-none-any.whl", hash = "sha256:617a90ceda2162ebf81cd13ad17d879bd4f49e7fb5c4f177bb905272555a2268"},
 ]
+natsort = [
+    {file = "natsort-8.1.0-py3-none-any.whl", hash = "sha256:f59988d2f24e77b6b56f8a8f882d5df6b3b637e09e075abc67b486d59fba1a4b"},
+    {file = "natsort-8.1.0.tar.gz", hash = "sha256:c7c1f3f27c375719a4dfcab353909fe39f26c2032a062a8c80cc844eaaca0445"},
+]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
@@ -1381,6 +1423,9 @@ requests = [
     {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
     {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
 ]
+seedir = [
+    {file = "seedir-0.3.0-py3-none-any.whl", hash = "sha256:2f55960022a142306076668ad6ba598076ae0f532148b0e8df527a91c24658a7"},
+]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
@@ -1390,8 +1435,8 @@ snowballstemmer = [
     {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
 ]
 soupsieve = [
-    {file = "soupsieve-2.3.1-py3-none-any.whl", hash = "sha256:1a3cca2617c6b38c0343ed661b1fa5de5637f257d4fe22bd9f1338010a1efefb"},
-    {file = "soupsieve-2.3.1.tar.gz", hash = "sha256:b8d49b1cd4f037c7082a9683dfa1801aa2597fb11c3a1155b7a5b94829b4f1f9"},
+    {file = "soupsieve-2.3.2-py3-none-any.whl", hash = "sha256:a714129d3021ec17ce5be346b1007300558b378332c289a1a20e7d4de6ff18a5"},
+    {file = "soupsieve-2.3.2.tar.gz", hash = "sha256:0bcc6d7432153063e3df09c3ac9442af3eba488715bfcad6a4c38ccb2a523124"},
 ]
 sphinx = [
     {file = "Sphinx-4.3.2-py3-none-any.whl", hash = "sha256:6a11ea5dd0bdb197f9c2abc2e0ce73e01340464feaece525e64036546d24c851"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ repository = "https://github.com/Robpol86/sphinx-multi-theme"
 [tool.poetry.dependencies]
 python = "^3.6.2"
 # Project dependencies.
+seedir = "*"
 sphinx = "*"
 # Docs.
 sphinx-autobuild = {version = "*", optional = true}

--- a/tests/unit_tests/test_docs/test-print-files/off/conf.py
+++ b/tests/unit_tests/test_docs/test-print-files/off/conf.py
@@ -1,0 +1,9 @@
+"""Sphinx test configuration."""
+from sphinx_multi_theme.theme import MultiTheme
+
+
+exclude_patterns = ["_build"]
+extensions = ["sphinx_multi_theme.multi_theme"]
+master_doc = "index"
+nitpicky = True
+html_theme = MultiTheme(["classic"])

--- a/tests/unit_tests/test_docs/test-print-files/off/index.rst
+++ b/tests/unit_tests/test_docs/test-print-files/off/index.rst
@@ -1,0 +1,10 @@
+====
+Test
+====
+
+Sample documentation.
+
+.. toctree::
+    :caption: Main
+
+    other

--- a/tests/unit_tests/test_docs/test-print-files/off/other.rst
+++ b/tests/unit_tests/test_docs/test-print-files/off/other.rst
@@ -1,0 +1,5 @@
+=====
+Other
+=====
+
+Another page.

--- a/tests/unit_tests/test_docs/test-print-files/on/conf.py
+++ b/tests/unit_tests/test_docs/test-print-files/on/conf.py
@@ -1,0 +1,11 @@
+"""Sphinx test configuration."""
+from sphinx_multi_theme.theme import MultiTheme
+
+
+exclude_patterns = ["_build"]
+extensions = ["sphinx_multi_theme.multi_theme"]
+master_doc = "index"
+nitpicky = True
+html_theme = MultiTheme(["classic"])
+multi_theme_print_files = True
+multi_theme_print_files_style = "dash"

--- a/tests/unit_tests/test_docs/test-print-files/on/index.rst
+++ b/tests/unit_tests/test_docs/test-print-files/on/index.rst
@@ -1,0 +1,10 @@
+====
+Test
+====
+
+Sample documentation.
+
+.. toctree::
+    :caption: Main
+
+    other

--- a/tests/unit_tests/test_docs/test-print-files/on/other.rst
+++ b/tests/unit_tests/test_docs/test-print-files/on/other.rst
@@ -1,0 +1,5 @@
+=====
+Other
+=====
+
+Another page.

--- a/tests/unit_tests/test_docs/test_print_files.py
+++ b/tests/unit_tests/test_docs/test_print_files.py
@@ -1,0 +1,23 @@
+"""Tests."""
+import os
+from io import StringIO
+
+import pytest
+from sphinx.testing.util import SphinxTestApp
+
+ROOTS = ("print-files/off", "print-files/on")
+
+
+@pytest.mark.parametrize("testroot", [pytest.param(r, marks=pytest.mark.sphinx("html", testroot=r)) for r in ROOTS])
+def test_off(sphinx_app: SphinxTestApp, status: StringIO, testroot: str):
+    """Verify single-theme is the same as not using this feature."""
+    assert sphinx_app
+    logs = status.getvalue().strip()
+    lines = logs.splitlines()
+
+    if testroot.endswith("off"):
+        assert lines.count(f"|-_static{os.sep}") == 0
+        assert lines.count("|-index.html") == 0
+    else:
+        assert lines.count(f"|-_static{os.sep}") == 1
+        assert lines.count("|-index.html") == 1


### PR DESCRIPTION
Ran across a strange bug in another branch whilst building docs in Read
The Docs. For some reason when I was using os.fork() there the child
processes didn't write any HTML files. Adding this option in case the
issue resurfaces in the future to aid debugging.