### PR TITLE
.truncate, flatten_html_theme s/primary/active/

### DIFF
--- a/sphinx_multi_theme/theme.py
+++ b/sphinx_multi_theme/theme.py
@@ -85,6 +85,12 @@ class MultiTheme:
         themes = [t for t in self.themes if t.is_primary]
         return themes[0]
 
+    def truncate(self) -> List[Theme]:
+        """Remove all secondary themes, only keep the primary theme."""
+        removed_themes = self.themes[1:]
+        self.themes[:] = self.themes[:1]
+        return removed_themes
+
     def set_subdir_attrs(self):
         """Set subdir attribute for every theme except the first one."""
         primary_theme = self.themes[0]

--- a/tests/unit_tests/test_docs/test_print_files.py
+++ b/tests/unit_tests/test_docs/test_print_files.py
@@ -9,7 +9,7 @@ ROOTS = ("print-files/off", "print-files/on")
 
 
 @pytest.mark.parametrize("testroot", [pytest.param(r, marks=pytest.mark.sphinx("html", testroot=r)) for r in ROOTS])
-def test_off(sphinx_app: SphinxTestApp, status: StringIO, testroot: str):
+def test(sphinx_app: SphinxTestApp, status: StringIO, testroot: str):
     """Verify single-theme is the same as not using this feature."""
     assert sphinx_app
     logs = status.getvalue().strip()

--- a/tests/unit_tests/test_docs/test_single_theme.py
+++ b/tests/unit_tests/test_docs/test_single_theme.py
@@ -70,7 +70,7 @@ def test(sphinx_app: SphinxTestApp, outdir: Path, warning: StringIO, testroot: s
     warnings = warning.getvalue().strip()
     if testroot.endswith("incomplete"):
         warnings_sans_colors = re.sub(r"\x1b\[[0-9;]+m", "", warnings)
-        assert warnings_sans_colors == "WARNING: Sphinx config value for `html_theme` not a MultiTheme instance"
+        assert warnings_sans_colors == "WARNING: 🍴 Sphinx config value for `html_theme` not a MultiTheme instance"
     else:
         assert not warnings
 

--- a/tests/unit_tests/test_multi_theme.py
+++ b/tests/unit_tests/test_multi_theme.py
@@ -117,3 +117,22 @@ def test_subdir_attrs():
     first = "Theme(name='b', subdir='my_subdir', is_active=False)"
     second = "Theme(name='c', subdir='my_subdir', is_active=False)"
     assert exc.value.args[0] == f"Subdir collision: {first} and {second}"
+
+
+def test_truncate():
+    """Test."""
+    themes = MultiTheme(["a", "b", "c"])
+
+    removed = themes.truncate()
+    assert len(themes) == 1
+    assert themes[0].name == "a"
+    assert len(removed) == 2
+    assert removed[0].name == "b"
+    assert removed[1].name == "c"
+
+    assert themes.truncate() == []  # pylint: disable=use-implicit-booleaness-not-comparison
+    assert len(themes) == 1
+    assert themes[0].name == "a"
+    assert len(removed) == 2
+    assert removed[0].name == "b"
+    assert removed[1].name == "c"


### PR DESCRIPTION
Switching `flatten_html_theme()` back to active theme instead of primary
theme. Future implementation has changed.

Flattening html_theme before other Sphinx extensions use the
"config-inited" event via priority=1.

Prefixing logging with an emoji to make log statements stand out more.

Don't print files on Sphinx exception. Can't do code coverage for this
branch because any exceptions break `sphinx.testing` and I couldn't find
a way for that to handle exceptions for me.

Adding `truncate()` method to `MultiTheme` for future use. Will be used
to remove secondary themes on Windows when forking is implemented.