### PR TITLE
Disable fail_under on Windows.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ fail_under = 85
 
 [tool.coverage.run]
 branch = true
+plugins = ["tests.unit_tests.conftest"]
 
 [tool.pylint.FORMAT]
 good-names = ["i", "j", "k", "ex", "Run", "_", "x", "y", "z", "fd"]

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -1,0 +1,28 @@
+"""pytest fixtures."""
+import os
+from typing import Dict
+
+import coverage
+from coverage.config import CoverageConfig
+from coverage.plugin_support import Plugins
+
+
+class CoverageConfigOverrides(coverage.CoveragePlugin):
+    """Override coverage configuration."""
+
+    def configure(self, config: CoverageConfig):
+        """Override configuration.
+
+        :param config: Coverage config.
+        """
+        if os.name == "nt":
+            config.set_option("report:fail_under", 0.0)  # Disable on Windows due to lack of os.fork().
+
+
+def coverage_init(reg: Plugins, _: Dict):
+    """Coverage plugin entrypoint (via pyproject.toml).
+
+    :param reg: Plugin registration entrypoint.
+    :param _: Unused.
+    """
+    reg.add_configurer(CoverageConfigOverrides())


### PR DESCRIPTION
Since Windows does not support os.fork() a lot of functions won't be
covered when tests run under Windows. Keeping Windows in unit tests
since the library should noop instead of forking.