### PR TITLE
Enabling Sphinx parallel compatibility.

### DIFF
--- a/sphinx_multi_theme/multi_theme.py
+++ b/sphinx_multi_theme/multi_theme.py
@@ -135,4 +135,4 @@ def setup(app: Sphinx) -> Dict[str, str]:
     app.connect("build-finished", print_files, priority=utils.SPHINX_CONNECT_PRIORITY_PRINT_FILES)
     app.connect("config-inited", flatten_html_theme, priority=utils.SPHINX_CONNECT_PRIORITY_FLATTEN_HTML_THEME)
     app.connect("config-inited", fork_sphinx, priority=utils.SPHINX_CONNECT_PRIORITY_FORK_SPHINX)
-    return dict(version=__version__)
+    return dict(parallel_read_safe=True, parallel_write_safe=True, version=__version__)

--- a/tests/unit_tests/test_docs/test-parallel/conf.py
+++ b/tests/unit_tests/test_docs/test-parallel/conf.py
@@ -1,0 +1,8 @@
+"""Sphinx test configuration."""
+from sphinx_multi_theme.theme import MultiTheme
+
+exclude_patterns = ["_build"]
+extensions = ["sphinx_multi_theme.multi_theme"]
+master_doc = "index"
+nitpicky = True
+html_theme = MultiTheme(["classic", "traditional", "alabaster"])

--- a/tests/unit_tests/test_docs/test-parallel/index.rst
+++ b/tests/unit_tests/test_docs/test-parallel/index.rst
@@ -1,0 +1,10 @@
+====
+Test
+====
+
+Sample documentation.
+
+.. toctree::
+    :caption: Main
+
+    other

--- a/tests/unit_tests/test_docs/test-parallel/other.rst
+++ b/tests/unit_tests/test_docs/test-parallel/other.rst
@@ -1,0 +1,5 @@
+=====
+Other
+=====
+
+Another page.

--- a/tests/unit_tests/test_docs/test_parallel.py
+++ b/tests/unit_tests/test_docs/test_parallel.py
@@ -1,0 +1,30 @@
+"""Tests."""
+import sys
+from pathlib import Path
+from subprocess import check_output, STDOUT
+from typing import Dict, Tuple
+
+import pytest
+
+
+@pytest.mark.usefixtures("skip_if_no_fork")
+@pytest.mark.parametrize("parallel", [False, True])
+@pytest.mark.sphinx("html", freshenv=True, testroot="parallel")
+def test(app_params: Tuple[Dict, Dict], parallel: bool):
+    """Test."""
+    srcdir = Path(app_params[1]["srcdir"])
+    outdir = srcdir / "_build" / "html"
+
+    # Generate documents.
+    with (srcdir / "index.rst").open("a", encoding="utf8") as index_rst:
+        for idx in range(20):
+            doc_rst = srcdir / f"doc{idx:03}.rst"
+            doc_rst.write_text(f"""======\nDoc{idx:03}\n======\n\nGenerated page.""", encoding="utf8")
+            index_rst.write(f"    doc{idx:03}\n")
+
+    # Build.
+    cmd = [sys.executable, "-m", "sphinx", "-T", "-n", "-W", srcdir, outdir]
+    if parallel:
+        cmd.insert(-2, "-j")
+        cmd.insert(-2, "2")
+    check_output(cmd, stderr=STDOUT, cwd=srcdir)

--- a/tests/unit_tests/test_docs/test_single_theme.py
+++ b/tests/unit_tests/test_docs/test_single_theme.py
@@ -60,6 +60,7 @@ def directory_compare(left: Optional[Path] = None, right: Optional[Path] = None,
     return file_count
 
 
+@pytest.mark.keep_srcdir
 @pytest.mark.parametrize(
     "testroot", [pytest.param(r, marks=pytest.mark.sphinx("html", freshenv=True, testroot=r)) for r in ROOTS]
 )


### PR DESCRIPTION
No code change, since besides parsing html_theme during config init no
environment/Sphinx data is altered by the extension.

Cleaning up session-scoped temporary test docs after every test.