### PR TITLE
No prefix on warning logs.

### DIFF
--- a/sphinx_multi_theme/multi_theme.py
+++ b/sphinx_multi_theme/multi_theme.py
@@ -37,7 +37,7 @@ def fork_sphinx(app: Sphinx, config: Config):
     try:
         themes = multi_theme_instance.themes
     except AttributeError:
-        log.warning("%sSphinx config value for `html_theme` not a %s instance", utils.LOGGING_PREFIX, MultiTheme.__name__)
+        log.warning("Sphinx config value for `html_theme` not a %s instance", MultiTheme.__name__)
         return
     if len(themes) < 2:
         return
@@ -46,7 +46,7 @@ def fork_sphinx(app: Sphinx, config: Config):
     if not hasattr(os, "fork"):
         removed = multi_theme_instance.truncate()
         removed_names = [t.name for t in removed]
-        log.warning("%sPlatform does not support forking, removing themes: %r", utils.LOGGING_PREFIX, removed_names)
+        log.warning("Platform does not support forking, removing themes: %r", removed_names)
         return
 
     # Fork and wait.

--- a/tests/unit_tests/test_docs/test_single_theme.py
+++ b/tests/unit_tests/test_docs/test_single_theme.py
@@ -86,9 +86,9 @@ def test(sphinx_app: SphinxTestApp, outdir: Path, warning: StringIO, testroot: s
     warnings = warning.getvalue().strip()
     warnings_sans_colors = re.sub(r"\x1b\[[0-9;]+m", "", warnings)
     if testroot.endswith("incomplete"):
-        assert warnings_sans_colors == "WARNING: 🍴 Sphinx config value for `html_theme` not a MultiTheme instance"
+        assert warnings_sans_colors == "WARNING: Sphinx config value for `html_theme` not a MultiTheme instance"
     elif testroot.endswith("no-fork"):
-        assert warnings_sans_colors == "WARNING: 🍴 Platform does not support forking, removing themes: ['fake1', 'fake2']"
+        assert warnings_sans_colors == "WARNING: Platform does not support forking, removing themes: ['fake1', 'fake2']"
     else:
         assert not warnings
 


### PR DESCRIPTION
Added prefix so the emoji will be the first character, but the logger
prepends "WARNING:" to log statements. Having the emoji right after that
doesn't look good.