### PR TITLE
make test print Sphinx version, restyle ci.yml.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,41 @@ jobs:
         exclude:
           - os: windows-latest
             python: "3.6"
-    runs-on: "${{matrix.os}}"
+    runs-on: "${{ matrix.os }}"
     steps:
-      - {name: Check out repository code, uses: actions/checkout@v2}
-      - {name: Initialize dependencies, uses: Robpol86/actions-init-deps-py@v3, with: {python-version: "${{matrix.python}}"}}
-      - {name: Run tests, run: make test, env: {PY_COLORS: 1}}
-      - {name: Upload coverage, uses: codecov/codecov-action@v2, with: {name: "coverage-${{runner.os}}-${{matrix.python}}"}}
-      - {name: Run lints, run: make lint}
-      - {name: Run integration tests, run: make it}
-      - {name: Build docs, run: make docs, if: "runner.os != 'Windows'"}
-      - {name: Build package, run: make build && cd dist && unzip -t *.whl && unzip -p *.whl '*/METADATA'}
+
+      - name: Check out repository code
+        uses: actions/checkout@v2
+
+      - name: Initialize dependencies
+        uses: Robpol86/actions-init-deps-py@v3
+        with:
+          cache-buster: "${{ join(matrix.*, '|') }}"
+          python-version: "${{ matrix.python }}"
+
+      - name: Run tests
+        env:
+          PY_COLORS: 1
+        run: make test
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v2
+        with:
+          name: "coverage-${{ runner.os }}-${{ join(matrix.*, '|') }}"
+
+      - name: Run lints
+        run: make lint
+
+      - name: Run integration tests
+        run: make it
+
+      - name: Build docs
+        if: runner.os != 'Windows'
+        run: make docs
+
+      - name: Build package
+        run: |
+          make build
+          cd dist
+          unzip -t *.whl
+          unzip -p *.whl '*/METADATA'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ in the project's directory run this if you're on macOS (requires [Homebrew](http
 brew install python@3.7
 brew install poetry  # More info: https://python-poetry.org
 make clean
-make PYTHON_PATH="$(brew --prefix)/opt/python@3.7/bin/python3" init
+make PROJECT_PY_PATH="$(brew --prefix)/opt/python@3.7/bin/python3" init
 make deps
 ```
 
@@ -21,7 +21,7 @@ On Ubuntu (including Windows WSL2):
 sudo apt-get update && sudo apt-get install make python3-virtualenv python3
 curl -sSL https://install.python-poetry.org | python3 -
 make clean
-make PYTHON_VERSION=3.7 init
+make PROJECT_PY_VERSION=3.7 init
 make deps
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,14 @@ export POETRY_VIRTUALENVS_IN_PROJECT = true
 
 ## Dependencies
 
-init: _HELP = Initialize Python VirtualEnv via Poetry (optional PYTHON_PATH or PYTHON_VERSION env vars)
-init: PYTHON_VERSION ?= 3
+init: _HELP = Initialize Python VirtualEnv via Poetry (optional PROJECT_PY_PATH or PROJECT_PY_VERSION env vars)
+init: PROJECT_PY_VERSION ?= 3
 init:
-ifdef PYTHON_PATH
-	poetry env use $(PYTHON_PATH)
+ifdef PROJECT_PY_PATH
+	poetry env use $(PROJECT_PY_PATH)
 else
-	command -V python$(PYTHON_VERSION) < /dev/null
-	poetry env use $(shell command -v python$(PYTHON_VERSION) < /dev/null)
+	command -V python$(PROJECT_PY_VERSION) < /dev/null
+	poetry env use $(shell command -v python$(PROJECT_PY_VERSION) < /dev/null)
 endif
 
 poetry.lock: _HELP = Lock dependency versions to file

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""pytest conftest."""
+import pytest
+from sphinx import __display_version__
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_report_header(*_):
+    """Include library versions in output before tests start."""
+    return f"libraries: Sphinx-{__display_version__}"

--- a/tests/unit_tests/test_docs/conftest.py
+++ b/tests/unit_tests/test_docs/conftest.py
@@ -1,4 +1,4 @@
-"""pytest fixtures."""
+"""pytest conftest."""
 import os
 import sys
 from io import StringIO


### PR DESCRIPTION
Re-styling ci.yml. Make it more human readable. Also include all matrix
values in unique keys.

Rename Makefile environment variables due to collision with official
Python docker images.

Print Sphinx version in pytest header before tests start.