### PR TITLE
Use poetry install in ReadTheDocs.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,19 +7,17 @@ version: 2
 # Set the version of Python and other tools you might need
 build:
   os: ubuntu-20.04
-  tools: {python: "3.9"}
+  tools: {python: "3.10"}
   jobs:
-    pre_install:
-      - curl -sSL https://install.python-poetry.org |python3 -
-      - PATH="$HOME/.local/bin:$PATH" make requirements.txt
+    pre_create_environment:
+      - asdf plugin add poetry
+      - asdf install poetry latest
+      - asdf global poetry latest
+      - poetry config virtualenvs.create false
+    post_install:
+      - poetry install
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
   fail_on_warning: true
-
-# Optionally declare the Python requirements required to build your docs
-python:
-  install:
-    - path: .
-    - requirements: requirements.txt


### PR DESCRIPTION
Dropping requirements.txt approach for pure Poetry when building docs in
ReadTheDocs. Fixes Python 3.10 problem.