### PR TITLE
Print exceptions in child processes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,10 +61,6 @@ deps: _HELP = Install project dependencies
 deps:
 	poetry install
 
-requirements.txt: _HELP = Generate development requirements.txt
-requirements.txt: poetry.lock
-	poetry export --dev --without-hashes -o $@
-
 ## Testing
 
 .PHONY: lint

--- a/sphinx_multi_theme/utils.py
+++ b/sphinx_multi_theme/utils.py
@@ -1,6 +1,7 @@
 """Avoid circular imports and other misc code."""
 import os
 import sys
+import traceback
 from os import _exit as os_exit  # noqa
 from os import waitpid
 from pathlib import Path
@@ -53,10 +54,14 @@ def terminate_forked_build(app: Sphinx, exc: Optional[Exception]):
     :param app: Sphinx app instance
     :param exc: Exception during build if it failed.
     """
+    if exc:
+        print(traceback.format_exc())
+
     log = logging.getLogger(__file__)
-    log.info("%sChild process completed", LOGGING_PREFIX)
+    log.info("%sChild process %s", LOGGING_PREFIX, "failed" if exc else "completed")
     sys.stdout.flush()
     sys.stderr.flush()
+
     exit_status = 1 if exc else 0
     app.emit("multi-theme-child-before-exit", exit_status, exc)
     os_exit(exit_status)

--- a/tests/unit_tests/test_docs/test-fork-failed/conf.py
+++ b/tests/unit_tests/test_docs/test-fork-failed/conf.py
@@ -17,8 +17,13 @@ html_theme = MultiTheme(["classic", "traditional", "alabaster"])
 def setup(app: Sphinx):
     """Cause failure."""
 
-    def callback(*_):
+    def callback_env_updated(*_):
+        if os.environ.get("TEST_ENV_UPDATED_CAUSE_EXC") == "TRUE":
+            raise SphinxError("TEST_ENV_UPDATED_CAUSE_EXC")
+
+    def callback_after_fork_child(*_):
         if os.environ.get("TEST_EXIT_STATUS_CAUSE_EXC") == "TRUE":
             raise SphinxError("TEST_EXIT_STATUS_CAUSE_EXC")
 
-    app.connect("multi-theme-after-fork-child", callback)
+    app.connect("multi-theme-after-fork-child", callback_after_fork_child)
+    app.connect("env-updated", callback_env_updated)


### PR DESCRIPTION
Oversight when implementing this Sphinx hook function. It was gobbling
up the exception thanks to os._exit(). Fixed by printing before
os._exit().

Removing unreliable and unused requirements.txt Makefile target.
ReadTheDocs uses Poetry now thanks to previous PR.