### PR TITLE
Fixed AttributeError during non-HTML builds.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,6 +16,8 @@ build:
       - poetry config virtualenvs.create false
     post_install:
       - poetry install
+#    pre_build:  # TODO uncomment after publishing to PyPI.
+#      - sphinx-build -W --keep-going -q -b linkcheck -d _build/doctrees docs/ _build/linkcheck
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/sphinx_multi_theme/nodes.py
+++ b/sphinx_multi_theme/nodes.py
@@ -16,7 +16,7 @@ class MultiThemeTocTreeNode(addnodes.toctree):
     def docname(self) -> str:
         """Get the current Sphinx document name (e.g. "index")."""
         env = self.document.settings.env  # noqa
-        return env.app.builder.current_docname or self.attributes["parent"]
+        return getattr(env.app.builder, "current_docname", None) or self.attributes["parent"]
 
     def get_ref(self, key) -> Optional[str]:
         """Return the relative link to a theme or an empty string if key out of scope."""

--- a/tests/unit_tests/test_docs/test-toctree-directive/links/conf.py
+++ b/tests/unit_tests/test_docs/test-toctree-directive/links/conf.py
@@ -1,8 +1,12 @@
 """Sphinx test configuration."""
+import os
+
 from sphinx_multi_theme.theme import MultiTheme, Theme
 
 exclude_patterns = ["_build"]
-extensions = ["sphinx_multi_theme.multi_theme", "conftest_fork_exit_save_child_data"]
+extensions = ["sphinx_multi_theme.multi_theme"]
+if os.environ.get("TEST_IN_SUBPROCESS") != "TRUE":
+    extensions.append("conftest_fork_exit_save_child_data")
 master_doc = "index"
 nitpicky = True
 html_theme = MultiTheme(


### PR DESCRIPTION
Attribute `current_docname` isn't guaranteed to be available for all
Sphinx builders.