### PR TITLE
Disable directive when only one theme is used.

### DIFF
--- a/sphinx_multi_theme/directives.py
+++ b/sphinx_multi_theme/directives.py
@@ -39,6 +39,9 @@ class MultiThemeTocTreeDirective(other.TocTree):
             log.warning("Extension not fully initialized: no multi-themes specified")
             self.options["hidden"] = True
             return []
+        if len(multi_theme.themes) < 2:
+            self.options["hidden"] = True
+            return []
 
         # Populate entries.
         entries: List[Tuple[str, str]] = toctree.setdefault("entries", [])

--- a/tests/unit_tests/test_docs/test-toctree-directive/single/conf.py
+++ b/tests/unit_tests/test_docs/test-toctree-directive/single/conf.py
@@ -1,0 +1,16 @@
+"""Sphinx test configuration."""
+import os
+
+from sphinx_multi_theme.theme import MultiTheme, Theme
+
+exclude_patterns = ["_build"]
+extensions = ["sphinx_multi_theme.multi_theme"]
+if os.environ.get("TEST_IN_SUBPROCESS") != "TRUE":
+    extensions.append("conftest_fork_exit_save_child_data")
+master_doc = "index"
+nitpicky = True
+html_theme = MultiTheme(
+    [
+        Theme("sphinx_rtd_theme", "Primary"),
+    ]
+)

--- a/tests/unit_tests/test_docs/test-toctree-directive/single/index.rst
+++ b/tests/unit_tests/test_docs/test-toctree-directive/single/index.rst
@@ -1,0 +1,13 @@
+====
+Test
+====
+
+Sample documentation.
+
+.. toctree::
+    :caption: Main
+
+    other
+
+.. multi-theme-toctree::
+    :caption: MultiTheme

--- a/tests/unit_tests/test_docs/test-toctree-directive/single/other.rst
+++ b/tests/unit_tests/test_docs/test-toctree-directive/single/other.rst
@@ -1,0 +1,5 @@
+=====
+Other
+=====
+
+Another page.

--- a/tests/unit_tests/test_docs/test_toctree_directive.py
+++ b/tests/unit_tests/test_docs/test_toctree_directive.py
@@ -121,6 +121,16 @@ def test_links(html: HTML):
     assert "current" in links_sub[1]["class"]
 
 
+@pytest.mark.sphinx("html", freshenv=True, testroot="toctree-directive/single")
+def test_single(outdir: Path):
+    """Test."""
+    for file_ in ("index.html", "other.html"):
+        html = BeautifulSoup((outdir / file_).read_text(encoding="utf8"), "html.parser")
+        assert "MultiTheme" not in html.text
+        assert "Primary" not in html.text
+        assert "Secondary" not in html.text
+
+
 @pytest.mark.usefixtures("skip_if_no_fork")
 @pytest.mark.sphinx("linkcheck", freshenv=True, testroot="toctree-directive/links")
 def test_linkcheck(app_params: Tuple[Dict, Dict]):


### PR DESCRIPTION
Mitigates warnings created by the epub builder. Using this extension
with one theme is also out of scope and should act as if the extension
doesn't exist.