### PR TITLE
Drop 3.6 from CI, drop Robpol86/actions-init-deps-py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
 
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Overwrite pyproject.toml and poetry.lock
         if: matrix.poetry-min
@@ -29,11 +29,22 @@ jobs:
           cp -v poetry{-min,}.lock
           git diff --color
 
-      - name: Initialize dependencies
-        uses: Robpol86/actions-init-deps-py@v3
+      - name: Install Poetry
+        shell: bash
+        # TODO latest poetry
+        run: pipx install poetry==1.1.13 && poetry config virtualenvs.in-project true
+
+      - name: Install Python
+        id: python
+        uses: actions/setup-python@v4
         with:
-          cache-buster: "${{ join(matrix.*, '|') }}"
           python-version: "${{ matrix.python }}"
+          cache: poetry
+
+      - name: Install dependencies
+        shell: bash
+        if: steps.python.outputs.cache-hit != 'true'
+        run: poetry install
 
       - name: Run tests
         env:
@@ -41,7 +52,7 @@ jobs:
         run: make test
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           name: "coverage-${{ runner.os }}-${{ join(matrix.*, '|') }}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python: ["3.7", "3.8", "3.9", "3.10"]
         poetry-min: ["", "poetry-min"]
         exclude:
-          - {os: windows-latest, python: "3.6"}
           - {os: windows-latest, poetry-min: "poetry-min"}
           - {os: macos-latest, poetry-min: "poetry-min"}
     runs-on: "${{ matrix.os }}"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,8 +14,8 @@ build:
   jobs:
     pre_create_environment:
       - asdf plugin add poetry
-      - asdf install poetry 1.1.13  # TODO latest
-      - asdf global poetry 1.1.13  # TODO latest
+      - asdf install poetry latest
+      - asdf global poetry latest
       - poetry config virtualenvs.create false
     post_install:
       - poetry install

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,10 +12,8 @@ build:
   os: ubuntu-20.04
   tools: {python: "3.10"}
   jobs:
-    pre_create_environment:
-      - asdf plugin add poetry
-      - asdf install poetry latest
-      - asdf global poetry latest
+    post_create_environment:
+      - pip install poetry
       - poetry config virtualenvs.create false
     post_install:
       - poetry install

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,8 +14,8 @@ build:
   jobs:
     pre_create_environment:
       - asdf plugin add poetry
-      - asdf install poetry latest
-      - asdf global poetry latest
+      - asdf install poetry 1.1.13  # TODO latest
+      - asdf global poetry 1.1.13  # TODO latest
       - poetry config virtualenvs.create false
     post_install:
       - poetry install


### PR DESCRIPTION
* Removing Python 3.6 from CI, it's EOL and gone from the setup-python action.
* Removing Robpol86/actions-init-deps-py, setup-python supports Poetry caching now.
* Pinning to an old Poetry version (same used before) for now.
* RTD changed and Poetry no longer auto-detected the virtualenv path, following official documentation as a fix: https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-poetry